### PR TITLE
MNT: add tests dir to the source distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
-from setuptools import setup
+from setuptools import setup, find_packages
 from sys import version_info
 
 ver = version_info[:3]
-if ver < (3, 5, 2):
-    raise SystemExit('Sorry! multio requires python 3.5.2 or later.')
+min_py_ver = (3, 5, 2)
+min_py_ver_str = '.'.join([str(x) for x in min_py_ver])
+if ver < min_py_ver:
+    raise SystemExit('Sorry! multio requires python {} or later.'.format(min_py_ver_str))
 
 setup(
     name='multio',
@@ -14,10 +16,8 @@ setup(
     version='0.2.5',
     author='theelous3, SunDwarf, and Akuli',
     url='https://github.com/theelous3/multio',
-    python_requires=">=3.5.2",
-    packages=[
-        'multio'
-    ],
+    python_requires=">={}".format(min_py_ver_str),
+    packages=find_packages(),
     classifiers=[
         'Programming Language :: Python :: 3',
         'Framework :: Trio',


### PR DESCRIPTION
This PR updates `setup.py` to also add the `tests` folder into the source distribution. Motivation: we'd like to have the pytest testing during a conda build, which [uses](https://github.com/nsls-ii-forge/multio-feedstock/blob/3f91393879617779a077ca5e9763b8aef29ef1ad/recipe/meta.yaml#L9
) the sources from [PyPI](https://pypi.org/project/multio/0.2.5/#files), see https://github.com/nsls-ii-forge/multio-feedstock/pull/1#issuecomment-518719567 for more details. Conda-forge's feedstock can benefit from that as well.

`python setup.py sdist` produces an archive with the following contents:
```
$ tree dist/multio-0.2.5
dist/multio-0.2.5
├── PKG-INFO
├── README.md
├── multio
│   ├── __init__.py
│   ├── _event_loop_wrappers.py
│   ├── _low_level.py
│   └── tests
│       ├── __init__.py
│       └── test_multio.py
├── multio.egg-info
│   ├── PKG-INFO
│   ├── SOURCES.txt
│   ├── dependency_links.txt
│   ├── requires.txt
│   └── top_level.txt
├── setup.cfg
└── setup.py
```

Also, I parametrized the minimum supported version of Python:
```bash
$ python -V
Python 2.7.16 :: Anaconda, Inc.
$ pip install .
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Processing /Users/mrakitin/src/mrakitin/open-source/multio
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: Sorry! multio requires python 3.5.2 or later.
    ----------------------------------------
ERROR: Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/r9/r6qc0r2j115dw226s61x4jv80000gn/T/pip-req-build-y5ZPyk/
```

```bash
$ python -V
Python 3.7.3
$ pip install .
Processing /Users/mrakitin/src/mrakitin/open-source/multio
Building wheels for collected packages: multio
  Building wheel for multio (setup.py) ... done
  Stored in directory: /private/var/folders/r9/r6qc0r2j115dw226s61x4jv80000gn/T/pip-ephem-wheel-cache-k0xobk76/wheels/14/cb/98/b3930da4db31762727374eae5feb939dbfd0273181bb1dc346
Successfully built multio
Installing collected packages: multio
Successfully installed multio-0.2.5
```